### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Supported Versions
+
+The following versions of this project are currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| #.#.#   | :white_check_mark: |
+| #.#.#   | :white_check_mark: |
+| <#.#.#  | :x:                |
+
+## Reporting a Vulnerability
+
+To report a security issue please email details to opensourcesecurity@wpengine.com with a descriptive subject line.  This account is monitored by a small team within WP Engine.  In addition, please include the following information along with your report:
+
+- Your name and affiliation (if any).
+- A description of the technical details of the vulnerability.  It is very important to let us know how we can reproduce your findings.
+- An explanation of who can exploit this vulnerability and what they gain when doing so -- write an attack scenario.  This will help us evaluate your report quickly, especially if the issue is complex.
+- Whether this vulnerability is public or known to third parties.  If it is, please provide details.
+
+If you believe that an existing (public) issue is security-related, please send an email to opensourcesecurity@wpengine.com.  The email should include the issue ID and a short description of why it should be handled according to this security policy.
+
+## Responding to Vulnerability Reports
+
+WP Engine takes security bugs seriously.  We appreciate your efforts to disclose your findings responsibly and will make every effort to acknowledge your contributions.
+
+Your email will be acknowledged within ONE business day, and you will receive a more detailed response to your email within SEVEN days indicating the next steps in handling your report.  After the initial reply to your report, WP Engine will keep you informed of the progress being made towards a fix and announcement.  If your vulnerability report is accepted, then we will work with you on a fix and follow the process noted below on [disclosing vulnerabilities](#disclosing-a-vulnerability).  If your vulnerability report is declined, then we will provide you with a reasoning as to why we came to that conclusion.
+
+## Disclosing a Vulnerability
+
+Once an issue is reported, WP Engine uses the following disclosure process:
+
+- When a report is received, we confirm the issue and determine its severity.
+- If we know of specific third-party services or software that require mitigation before publication, those projects will be notified.
+- An advisory is prepared (but not published) which details the problem and steps for mitigation.
+- Wherever possible, fixes are prepared for the last minor release of the two latest major releases, as well as the trunk branch.  We will attempt to commit these fixes as soon as possible, and as close together as possible.
+- Patch releases are published for all fixed released versions and the advisory is published.
+- Release notes and our CHANGELOG.md will include a `Security` section with a link to the advisory.
+
+We credit reporters for identifying vulnerabilities, although we will keep your name confidential if you request it.
+
+## Known Vulnerabilities
+
+Past security advisories, if any, are listed below.
+
+| Advisory Number | Type               | Versions affected | Reported by           | Additional Information      |
+|-----------------|--------------------|:-----------------:|-----------------------|-----------------------------|
+| -               | -                  | -                 | -                     | -                           |
+| -               | -                  | -                 | -                     | -                           |


### PR DESCRIPTION
Referencing GitHub's [Adding a security policy to your repository](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository). 

It is crucial to note that creating the `SECURITY.md` in the WP Engine's organizational `.github` repository (this current repository) will propagate to any existing WP Engine public repository that does not currently have its own existing `SECURITY.md`.

> [!CAUTION]
> The steps below will need to be completed before merging this pull request!

Damon Cook will be responsible for executing the following before accepting this merge request.

- [ ] Need to create an email associated with policy: `opensourcesecurity@wpengine.com`
- [ ] Need to verify with the WP Engine Security team that this policy is adequate.
- [ ] Need to follow up with existing WP Engine teams and code owners to make them aware of this critical change as it relates to their public repositories.

[Preview of the proposed SECURITY.md](https://github.com/wpengine/.github/pull/1/files?short_path=f6ed156#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7)