### PR TITLE
Remove Jenkins-generated CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-* @wpengine/developer-relations
-
-#jira:WPC is where issues related to this repository should be ticketed


### PR DESCRIPTION
We'll revisit with more oversight on what default CODEOWNERS should look like.